### PR TITLE
Update renderer.py to use open rather than file()

### DIFF
--- a/appy/pod/renderer.py
+++ b/appy/pod/renderer.py
@@ -398,13 +398,13 @@ class Renderer:
                 toInsert += ' <manifest:file-entry manifest:media-type="%s" ' \
                             'manifest:full-path="%s"/>\n' % (mimeType, fileName)
             manifestName = j(self.unzipFolder, j('META-INF', 'manifest.xml'))
-            f = file(manifestName)
+            f = open(manifestName)
             manifestContent = f.read()
             hook = '</manifest:manifest>'
             manifestContent = manifestContent.replace(hook, toInsert+hook)
             f.close()
             # Write the new manifest content
-            f = file(manifestName, 'w')
+            f = open(manifestName, 'w')
             f.write(manifestContent)
             f.close()
 


### PR DESCRIPTION
For python 3 compatibility. Has appy been abandoned? Why can't version 3 support be pushed to the original appy code?